### PR TITLE
Fix Error response from daemon: No such image: echo-app:v2

### DIFF
--- a/labs/[1739]_scale_out_and_update_a_containerized_application_on_a_kubernetes_cluster/guide.txt
+++ b/labs/[1739]_scale_out_and_update_a_containerized_application_on_a_kubernetes_cluster/guide.txt
@@ -6,7 +6,7 @@ Task 1 : Check that there is a tagged image in gcr.io for echo-app:v2
 - gsutil cp -r gs://$DEVSHELL_PROJECT_ID/echo-web-v2.tar.gz .
 - tar -xzf echo-web-v2.tar.gz
 - rm echo-web-v2.tar.gz
-- docker build -t echo-app:v1 .
+- docker build -t echo-app:v2 .
 - docker tag echo-app:v2 gcr.io/$DEVSHELL_PROJECT_ID/echo-app:v2
 - docker push gcr.io/$DEVSHELL_PROJECT_ID/echo-app:v2
 


### PR DESCRIPTION
Got this error when doing lab 'Scale Out and Update a Containerized Application on a Kubernetes Cluster'
```
$ docker tag echo-app:v2 gcr.io/$DEVSHELL_PROJECT_ID/echo-app:v2
Error response from daemon: No such image: echo-app:v2
```

This PR should fix that by changing `docker build -t echo-app:v1 .` to `docker build -t echo-app:v2 .`