### PR TITLE
Add testing traffic sent to your instances

### DIFF
--- a/labs/gsp313_create-and-manage-cloud-resources/script.sh
+++ b/labs/gsp313_create-and-manage-cloud-resources/script.sh
@@ -70,3 +70,10 @@ gcloud compute forwarding-rules create http-content-rule \
     --global \
     --target-http-proxy http-lb-proxy \
     --ports 80
+    
+## 3.9 Testing traffic sent to your instances
+## Network services > Load balancing
+## Click web-map
+## Click the name of the backend
+## Open new tab
+## Paste http://IP_ADDRESS/ in the URL bar (replace IP_ADDRESS with the load balancer's IP address)


### PR DESCRIPTION
Task 3 in Create and Manage Cloud Resources: Challenge Lab will only reach 40/60 without this.